### PR TITLE
Generic options

### DIFF
--- a/gluestring/default.py
+++ b/gluestring/default.py
@@ -1,0 +1,8 @@
+DEFAULT_DICTIONARY = {
+    "default": "NA"
+}
+
+DEFAULT_DELIMITERS = {
+    "start": "{{",
+    "end": "}}",
+}

--- a/gluestring/default.py
+++ b/gluestring/default.py
@@ -6,3 +6,7 @@ DEFAULT_DELIMITERS = {
     "start": "{{",
     "end": "}}",
 }
+
+DEFAULT_OPTIONS = {
+    "delimiters" : DEFAULT_DELIMITERS,
+}

--- a/gluestring/gluegun.py
+++ b/gluestring/gluegun.py
@@ -4,9 +4,16 @@ DEFAULT_DICTIONARY = {
     "default": "NA"
 }
 
+DEFAULT_DELIMITERS = {
+    "start": "{{",
+    "end": "}}",
+}
+
 
 class Gluegun:
-    def __init__(self, mapping=DEFAULT_DICTIONARY):
+
+    def __init__(self, mapping=DEFAULT_DICTIONARY, delimiters=DEFAULT_DELIMITERS):
+        self.set_delimiters(delimiters)
         if (type(mapping) is dict):
             self.mapping = {**DEFAULT_DICTIONARY, **mapping}
         elif (type(mapping) is list):
@@ -19,12 +26,26 @@ class Gluegun:
             raise Exception(
                 'Excpected type of mapping to be a dictionary or a list of dictionary. Got type {}'.format(type(mapping)))
 
+    def set_delimiters(self, delimiters):
+        if type(delimiters is dict):
+            if "start" in delimiters and "end" in delimiters:
+                self.delimiters = delimiters
+            else:
+                raise Exception(
+                    'Expected a dictionary with "start" and "end" as keys.'
+                )
+        else:
+            raise Exception(
+                'Excpected type of delimiters to be a dictionary. Got type {}'.format(
+                    type(delimiters))
+            )
+
     def glue_it(self, input_template):
         if type(input_template) is list and type(self.mapping) is list:
-            return resolve_mxn(input_template, self.mapping)
+            return resolve_mxn(input_template, self.mapping, self.delimiters)
         elif type(input_template) is list and type(self.mapping) is dict:
-            return resolve_mxn(input_template, [self.mapping])
+            return resolve_mxn(input_template, [self.mapping], self.delimiters)
         elif type(input_template) is str and type(self.mapping) is list:
-            return resolve_mxn([input_template], self.mapping)
+            return resolve_mxn([input_template], self.mapping, self.delimiters)
         elif type(input_template) is str and type(self.mapping) is dict:
-            return resolve_string(input_template, self.mapping)
+            return resolve_string(input_template, self.mapping, self.delimiters)

--- a/gluestring/gluegun.py
+++ b/gluestring/gluegun.py
@@ -1,13 +1,5 @@
 from gluestring.main import resolve_mxn, resolve_string
-
-DEFAULT_DICTIONARY = {
-    "default": "NA"
-}
-
-DEFAULT_DELIMITERS = {
-    "start": "{{",
-    "end": "}}",
-}
+from gluestring.default import DEFAULT_DICTIONARY, DEFAULT_DELIMITERS
 
 
 class Gluegun:

--- a/gluestring/gluegun.py
+++ b/gluestring/gluegun.py
@@ -1,11 +1,13 @@
 from gluestring.main import resolve_mxn, resolve_string
-from gluestring.default import DEFAULT_DICTIONARY, DEFAULT_DELIMITERS
+from gluestring.default import DEFAULT_DICTIONARY, DEFAULT_DELIMITERS, DEFAULT_OPTIONS
 
 
 class Gluegun:
+    options = {}
+    def __init__(self, mapping=DEFAULT_DICTIONARY, options=DEFAULT_OPTIONS):
 
-    def __init__(self, mapping=DEFAULT_DICTIONARY, delimiters=DEFAULT_DELIMITERS):
-        self.set_delimiters(delimiters)
+        self.set_options(options)
+
         if (type(mapping) is dict):
             self.mapping = {**DEFAULT_DICTIONARY, **mapping}
         elif (type(mapping) is list):
@@ -18,10 +20,11 @@ class Gluegun:
             raise Exception(
                 'Excpected type of mapping to be a dictionary or a list of dictionary. Got type {}'.format(type(mapping)))
 
-    def set_delimiters(self, delimiters):
+    def set_delimiters(self, options):
+        delimiters = options.get("delimiters", None)
         if type(delimiters is dict):
             if "start" in delimiters and "end" in delimiters:
-                self.delimiters = delimiters
+                self.options['delimiters'] = delimiters
             else:
                 raise Exception(
                     'Expected a dictionary with "start" and "end" as keys.'
@@ -32,12 +35,28 @@ class Gluegun:
                     type(delimiters))
             )
 
+    def set_options(self, options):
+        if type(options) is dict:
+            self.options = options
+
+            if "delimiters" not in options:
+                self.options['delimiters'] = DEFAULT_DELIMITERS
+            else:
+                self.set_delimiters(options)
+
+        else:
+            raise Exception(
+                'Excpected type of options to be a dictionary. Got type {}'.format(
+                    type(options))
+            )
+        
+
     def glue_it(self, input_template):
         if type(input_template) is list and type(self.mapping) is list:
-            return resolve_mxn(input_template, self.mapping, self.delimiters)
+            return resolve_mxn(input_template, self.mapping, self.options)
         elif type(input_template) is list and type(self.mapping) is dict:
-            return resolve_mxn(input_template, [self.mapping], self.delimiters)
+            return resolve_mxn(input_template, [self.mapping], self.options)
         elif type(input_template) is str and type(self.mapping) is list:
-            return resolve_mxn([input_template], self.mapping, self.delimiters)
+            return resolve_mxn([input_template], self.mapping, self.options)
         elif type(input_template) is str and type(self.mapping) is dict:
-            return resolve_string(input_template, self.mapping, self.delimiters)
+            return resolve_string(input_template, self.mapping, self.options)

--- a/gluestring/main.py
+++ b/gluestring/main.py
@@ -1,4 +1,5 @@
 import re
+from gluestring.default import DEFAULT_DELIMITERS
 
 
 def _get_regex_delimiter(values):
@@ -7,7 +8,7 @@ def _get_regex_delimiter(values):
         delimiter += f"\{value}"
     return delimiter
 
-def resolve_string(templateString, dictionaryToMatch, delimiters):
+def resolve_string(templateString, dictionaryToMatch, delimiters=DEFAULT_DELIMITERS):
 
     pattern = re.compile(r'{start}([^{not_match}$]*){end}'.format(
         start=_get_regex_delimiter(delimiters['start']),
@@ -31,7 +32,7 @@ def resolve_string(templateString, dictionaryToMatch, delimiters):
 #     for templateString in templateStringList:
 
 
-def resolve_mxn(templateStringList, dictionaryToMatchList, delimiters):
+def resolve_mxn(templateStringList, dictionaryToMatchList, delimiters=DEFAULT_DELIMITERS):
     result = []
     for templateString in templateStringList:
         for dictionaryToMatch in dictionaryToMatchList:

--- a/gluestring/main.py
+++ b/gluestring/main.py
@@ -1,5 +1,5 @@
 import re
-from gluestring.default import DEFAULT_DELIMITERS
+from gluestring.default import DEFAULT_OPTIONS
 
 
 def _get_regex_delimiter(values):
@@ -8,8 +8,8 @@ def _get_regex_delimiter(values):
         delimiter += f"\{value}"
     return delimiter
 
-def resolve_string(templateString, dictionaryToMatch, delimiters=DEFAULT_DELIMITERS):
-
+def resolve_string(templateString, dictionaryToMatch, options=DEFAULT_OPTIONS):
+    delimiters = options['delimiters']
     pattern = re.compile(r'{start}([^{not_match}$]*){end}'.format(
         start=_get_regex_delimiter(delimiters['start']),
         not_match=delimiters['end'][0],
@@ -32,10 +32,11 @@ def resolve_string(templateString, dictionaryToMatch, delimiters=DEFAULT_DELIMIT
 #     for templateString in templateStringList:
 
 
-def resolve_mxn(templateStringList, dictionaryToMatchList, delimiters=DEFAULT_DELIMITERS):
+def resolve_mxn(templateStringList, dictionaryToMatchList, options=DEFAULT_OPTIONS):
+    
     result = []
     for templateString in templateStringList:
         for dictionaryToMatch in dictionaryToMatchList:
             result.append(resolve_string(templateString,
-                                         dictionaryToMatch, delimiters))
+                                         dictionaryToMatch, options))
     return result

--- a/gluestring/main.py
+++ b/gluestring/main.py
@@ -1,28 +1,40 @@
 import re
 
 
-def resolve_string(templateString, dictionaryToMatch):
-    pattern = re.compile(r'\{\{([^}$]*)\}\}')
-    number_of_patterns_found = len(pattern.findall(templateString))
+def _get_regex_delimiter(values):
+    delimiter = ""
+    for value in values:
+        delimiter += f"\{value}"
+    return delimiter
 
+def resolve_string(templateString, dictionaryToMatch, delimiters):
+
+    pattern = re.compile(r'{start}([^{not_match}$]*){end}'.format(
+        start=_get_regex_delimiter(delimiters['start']),
+        not_match=delimiters['end'][0],
+        end=_get_regex_delimiter(delimiters['end'])
+    ))
+    number_of_patterns_found = len(pattern.findall(templateString))
     for _ in range(number_of_patterns_found):
         val = pattern.search(templateString).groups()[0]
-
         if val.strip() in dictionaryToMatch:
             templateString = templateString.replace(
-                '{{'+val+'}}', str(dictionaryToMatch[val.strip()]), 1)
+                delimiters["start"]+val+delimiters["end"],
+                str(dictionaryToMatch[val.strip()]), 1)
         else:
             templateString = templateString.replace(
-                '{{'+val+'}}', str(dictionaryToMatch['default']), 1)
+                delimiters["start"]+val+delimiters["end"],
+                str(dictionaryToMatch['default']), 1)
     return templateString
 
 # def resolve_list(templateStringList, dictionaryToMatch ):
 #     for templateString in templateStringList:
 
 
-def resolve_mxn(templateStringList, dictionaryToMatchList):
+def resolve_mxn(templateStringList, dictionaryToMatchList, delimiters):
     result = []
     for templateString in templateStringList:
         for dictionaryToMatch in dictionaryToMatchList:
-            result.append(resolve_string(templateString, dictionaryToMatch))
+            result.append(resolve_string(templateString,
+                                         dictionaryToMatch, delimiters))
     return result

--- a/tests/test_gluegun.py
+++ b/tests/test_gluegun.py
@@ -16,6 +16,23 @@ class TestGluegun(unittest.TestCase):
         self.assertEqual(
             result_string, 'Get 30% off . Get 40% if SUPER user. ')
 
+    def test_gluegun__custom_delimiters(self):
+        delimiters = {"start": "[[", "end": "]]"}
+        g1 = Gluegun(offer_dictionary, delimiters)
+        temp_test_offer_string = test_offer_string.replace(
+            "{{", "[[").replace("}}", "]]")
+        result_string = g1.glue_it(temp_test_offer_string)
+        self.assertEqual(
+            result_string, 'Get 30% off . Get 40% if SUPER user. ')
+
+        delimiters = {"start": "<<", "end": ">>"}
+        g1 = Gluegun(offer_dictionary, delimiters)
+        temp_test_offer_string = test_offer_string.replace(
+            "{{", "<<").replace("}}", ">>")
+        result_string = g1.glue_it(temp_test_offer_string)
+        self.assertEqual(
+            result_string, 'Get 30% off . Get 40% if SUPER user. ')
+
     def test_gluegun__with_no_parameters_should_not_throw_error(self):
         g1 = Gluegun()
         result_string = g1.glue_it(test_offer_string)
@@ -77,35 +94,34 @@ class TestGluegun(unittest.TestCase):
             result_string_list[2], 'Hello my name is NA and 52')
 
     def test_gluegun_glueit__liststring_dictionary(self):
-        in_string = ["Hello my name is {{name}} and {{age}}","{{name}} is a good {{gender}}"]
+        in_string = [
+            "Hello my name is {{name}} and {{age}}", "{{name}} is a good {{gender}}"]
         in_dictionary = {
             "name": "Foo",
-            "gender":"woman"
+            "gender": "woman"
         }
         sut = Gluegun(in_dictionary)
         result_string_list = sut.glue_it(in_string)
 
-        self.assertEqual(len(result_string_list),2)
+        self.assertEqual(len(result_string_list), 2)
         self.assertEqual(
             result_string_list[0], 'Hello my name is Foo and NA')
         self.assertEqual(
             result_string_list[1], 'Foo is a good woman')
 
-
-
-
     def test_gluegun_glueit__liststring_listdictionary(self):
-        in_string = ["Hello my name is {{name}} and {{age}}","{{name}} is a good {{gender}}"]
+        in_string = [
+            "Hello my name is {{name}} and {{age}}", "{{name}} is a good {{gender}}"]
         in_dictionary = [{
             "name": "Foo",
-            "gender":"woman"
-        },{
-            "age":14
+            "gender": "woman"
+        }, {
+            "age": 14
         }]
         sut = Gluegun(in_dictionary)
         result_string_list = sut.glue_it(in_string)
 
-        self.assertEqual(len(result_string_list),4)
+        self.assertEqual(len(result_string_list), 4)
         self.assertEqual(
             result_string_list[0], 'Hello my name is Foo and NA')
         self.assertEqual(
@@ -114,7 +130,6 @@ class TestGluegun(unittest.TestCase):
             result_string_list[2], 'Foo is a good woman')
         self.assertEqual(
             result_string_list[3], 'NA is a good NA')
-
 
     # def test_gluegun_glueit__liststring_listdictionary(self):
 

--- a/tests/test_gluegun.py
+++ b/tests/test_gluegun.py
@@ -18,7 +18,7 @@ class TestGluegun(unittest.TestCase):
 
     def test_gluegun__custom_delimiters(self):
         delimiters = {"start": "[[", "end": "]]"}
-        g1 = Gluegun(offer_dictionary, delimiters)
+        g1 = Gluegun(offer_dictionary, {"delimiters": delimiters})
         temp_test_offer_string = test_offer_string.replace(
             "{{", "[[").replace("}}", "]]")
         result_string = g1.glue_it(temp_test_offer_string)
@@ -26,7 +26,7 @@ class TestGluegun(unittest.TestCase):
             result_string, 'Get 30% off . Get 40% if SUPER user. ')
 
         delimiters = {"start": "<<", "end": ">>"}
-        g1 = Gluegun(offer_dictionary, delimiters)
+        g1 = Gluegun(offer_dictionary, {"delimiters": delimiters})
         temp_test_offer_string = test_offer_string.replace(
             "{{", "<<").replace("}}", ">>")
         result_string = g1.glue_it(temp_test_offer_string)


### PR DESCRIPTION
I made a separate PR because in my opinion it was more user friendly with the delimiter parameter instead of wrapped in a dict `options`